### PR TITLE
Fix position and style for mobile top nav

### DIFF
--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -454,7 +454,6 @@ a {
   background-color: #72BEB6;
   color: white;
   position: absolute;
-  left: -8px;
   width: 100%;
   top: -90px;
   z-index: 100;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -19,8 +19,6 @@
     <li>{{#link-to 'achievements'}}<i class="fa fa-trophy icon"></i>Achievements{{/link-to}}</li>
   </ul>
 </nav>
-<div id="application-container">
-  {{outlet}}
 <nav id="top-menu" class="{{if isExpanded 'lowered' 'raised'}}">
   <ul>
     <li><a {{action 'menuLoad' 'events'}}><i class="fa fa-flag icon"></i> Event List</a></li>
@@ -36,6 +34,9 @@
   <p><a {{action 'openMenu'}} class="menu-button">Menu</a></p>
   {{/if}}
 </nav>
+<div id="application-container">
+  {{outlet}}
+
 </div>
 {{#if isModalVisible}}
   {{#modal-dialog}}


### PR DESCRIPTION
This should take care of that 8px right-hand gap we were seeing (without reintroducing the sidescrolling wonkiness)