### PR TITLE
Updated ember to release build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "tri-conf-app",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "release",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.0.0-beta.16.1",


### PR DESCRIPTION
Upgrades ember which fixes a memory leak: emberjs/ember.js/pull/11667
Cannot use 1.13.4 because of emberjs/ember.js#11744, so instead is pointing to latest stable until 1.13.5 is released.

This needs some good testing applied first before merging.